### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/es5/lib/usage-stats-core.js
+++ b/es5/lib/usage-stats-core.js
@@ -206,7 +206,7 @@ var UsageStats = function () {
     key: '_getClientId',
     value: function _getClientId() {
       var cid = null;
-      var uuid = require('node-uuid');
+      var uuid = require('uuid');
       var cidPath = path.resolve(this.dir, 'cid');
       try {
         cid = fs.readFileSync(cidPath, 'utf8');

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "feature-detect-es6": "^1.3.1",
     "home-path": "^1.0.3",
     "mkdirp": "^0.5.1",
-    "node-uuid": "^1.4.7",
     "req-then": "^0.5.1",
-    "typical": "^2.6.0"
+    "typical": "^2.6.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.18.0",

--- a/src/lib/usage-stats-core.js
+++ b/src/lib/usage-stats-core.js
@@ -304,7 +304,7 @@ class UsageStats {
    */
   _getClientId () {
     let cid = null
-    const uuid = require('node-uuid')
+    const uuid = require('uuid')
     const cidPath = path.resolve(this.dir, 'cid')
     try {
       cid = fs.readFileSync(cidPath, 'utf8')


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.